### PR TITLE
Fix default datetime values showing current timestamp

### DIFF
--- a/facade.php
+++ b/facade.php
@@ -763,6 +763,10 @@ function resolveDefaultValue($parameter)
         return '0755';
     }
 
+    if ($parameter['default'] instanceof DateTimeInterface) {
+        return get_class($parameter['default']);
+    }
+
     $default = json_encode($parameter['default']);
 
     return Str::of($default === false ? 'unknown' : $default)

--- a/facade.php
+++ b/facade.php
@@ -762,9 +762,9 @@ function resolveDefaultValue($parameter)
     if ($parameter['name'] === '$mode' && $parameter['default'] === 493) {
         return '0755';
     }
-
+    
     if ($parameter['default'] instanceof DateTimeInterface) {
-        return get_class($parameter['default']);
+        return 'new \\'.get_class($parameter['default']);
     }
 
     $default = json_encode($parameter['default']);


### PR DESCRIPTION
This PR fixes an issue where a method that has a default `DateTime` instance in a param produces a timestamp instead of the real default value.

For example, this:

```php
public function reportNow(Metric $metric, CarbonInterface $datetime = new CarbonImmutable): void;
```

Produces this:

```php
 * @method static void reportNow(\App\Services\Metrics\Metric $metric, \Carbon\CarbonInterface $datetime = '2025-06-05T17:24:10.594327Z')
```

After this PR:

```php
 * @method static void reportNow(\App\Services\Metrics\Metric $metric, \Carbon\CarbonInterface $datetime = new \Carbon\CarbonImmutable)
```