### PR TITLE
Resolve unqualified `@see` class names using `use` imports

### DIFF
--- a/facade.php
+++ b/facade.php
@@ -46,14 +46,6 @@ collect($argv)
             return;
         }
 
-        $proxies->map(function ($proxy) {
-            if (class_exists($proxy)) {
-                return $proxy;
-            }
-
-            $guessedFqcn = resolveClassImports($method->getDeclaringClass())->get($typeNode->name) ?? '\\'.$method->getDeclaringClass()->getNamespaceName().'\\'.$typeNode->name;
-        });
-
         // Build a list of methods that are available on the Facade...
 
         $resolvedMethods = $proxies->map(fn ($fqcn) => new ReflectionClass($fqcn))
@@ -141,8 +133,27 @@ exit(0);
  */
 function resolveDocSees($class)
 {
+    $imports = resolveClassImports($class);
+
     return resolveDocTags($class->getDocComment() ?: '', '@see ')
-        ->reject(fn ($tag) => str_starts_with($tag, 'https://'));
+        ->reject(fn ($tag) => str_starts_with($tag, 'https://'))
+        ->map(function ($tag) use ($class, $imports) {
+            if (str_starts_with($tag, '\\')) {
+                return $tag;
+            }
+
+            if ($resolved = $imports->get($tag)) {
+                return $resolved;
+            }
+
+            $fqcn = '\\'.$class->getNamespaceName().'\\'.$tag;
+
+            if (class_exists($fqcn) || interface_exists($fqcn)) {
+                return $fqcn;
+            }
+
+            return $tag;
+        });
 }
 
 /**


### PR DESCRIPTION
The documenter throws a fatal error when a facade's `@see` tag uses an unqualified class name that relies on a `use` import for resolution.

For example:

```php
use App\Services\MyService;

/**
 * @see MyService
 */
class MyFacade extends Facade {}
```

The `resolveDocSees` function returns the raw tag text (`MyService`) without considering the file's `use` imports, so `new ReflectionClass('MyService')` fails with a `ReflectionException`.

This PR moves the resolution into `resolveDocSees` itself, using the existing `resolveClassImports` helper to resolve unqualified names against the file's `use` statements. It also removes the `$proxies->map()` block added in 9789a7b, which attempted this fix but references undefined `$method` and `$typeNode` variables.
