### PR TITLE
Fix interface/enum resolution and preserve generic types

### DIFF
--- a/facade.php
+++ b/facade.php
@@ -327,15 +327,7 @@ function resolveDocblockTypes($method, $typeNode, $depth = 1)
             $determinedFqcn = determineFqcn($typeNode->name, $method->getDeclaringClass());
 
             foreach ([$typeNode->name, $determinedFqcn] as $name) {
-                if (class_exists($name)) {
-                    return Str::start((string) $name, '\\');
-                }
-
-                if (interface_exists($name)) {
-                    return Str::start((string) $name, '\\');
-                }
-
-                if (enum_exists($name)) {
+                if (class_exists($name) || interface_exists($name) || enum_exists($name)) {
                     return Str::start((string) $name, '\\');
                 }
 

--- a/facade.php
+++ b/facade.php
@@ -148,13 +148,13 @@ function determineFqcn($class, $source)
 {
     $importedFqcn = resolveClassImports($source)->get($class);
 
-    if ($importedFqcn && class_exists($importedFqcn)) {
+    if ($importedFqcn && (class_exists($importedFqcn) || interface_exists($importedFqcn) || enum_exists($importedFqcn))) {
         return $importedFqcn;
     }
 
     $namespacedFqcn = '\\'.$source->getNamespaceName().'\\'.$class;
 
-    if (class_exists($namespacedFqcn)) {
+    if (class_exists($namespacedFqcn) || interface_exists($namespacedFqcn) || enum_exists($namespacedFqcn)) {
         return $namespacedFqcn;
     }
 
@@ -278,7 +278,17 @@ function resolveDocblockTypes($method, $typeNode, $depth = 1)
         }
 
         if ($typeNode instanceof GenericTypeNode) {
-            return resolveDocblockTypes($method, $typeNode->type, $depth + 1);
+            $baseType = resolveDocblockTypes($method, $typeNode->type, $depth + 1);
+
+            $genericArgs = collect($typeNode->genericTypes)
+                ->map(fn ($node) => resolveDocblockTypes($method, $node, $depth + 1))
+                ->filter();
+
+            if ($genericArgs->isEmpty()) {
+                return $baseType;
+            }
+
+            return $baseType.'<'.$genericArgs->implode(', ').'>';
         }
 
         if ($typeNode instanceof ThisTypeNode) {
@@ -322,11 +332,11 @@ function resolveDocblockTypes($method, $typeNode, $depth = 1)
                 }
 
                 if (interface_exists($name)) {
-                    return (string) $name;
+                    return Str::start((string) $name, '\\');
                 }
 
                 if (enum_exists($name)) {
-                    return (string) $name;
+                    return Str::start((string) $name, '\\');
                 }
 
                 if (isKnownOptionalDependency($name)) {
@@ -452,7 +462,7 @@ function isBuiltIn($type)
     return in_array($type, [
         'null', 'bool', 'int', 'float', 'string', 'array', 'object',
         'resource', 'never', 'void', 'mixed', 'iterable', 'self', 'static',
-        'parent', 'true', 'false', 'callable',
+        'parent', 'true', 'false', 'callable', 'array-key',
     ]);
 }
 


### PR DESCRIPTION
This PR fixes:

- `determineFqcn` now checks `interface_exists` and `enum_exists` alongside `class_exists`, so interfaces like `Arrayable` and enums like `BackedEnum` resolve to their FQCN instead of falling through to `mixed`
- Generic type arguments are preserved (`array<array-key, mixed>` instead of `array`)
- Interfaces and enums get a `\` prefix, matching the existing `class_exists` branch
- `array-key` is recognized as a built-in pseudo-type