### PR TITLE
Fix unbalanced parens in @method when expanding union-typed template bounds

### DIFF
--- a/facade.php
+++ b/facade.php
@@ -326,7 +326,7 @@ function resolveDocblockTypes($method, $typeNode, $depth = 1)
                 }
             }
 
-            return handleUnknownIdentifierType($method, $typeNode);
+            return handleUnknownIdentifierType($method, $typeNode, $depth);
         }
 
         if ($typeNode instanceof ConditionalTypeNode) {
@@ -415,15 +415,21 @@ function resolveDocblockTypes($method, $typeNode, $depth = 1)
  *
  * @param  \ReflectionMethodDecorator  $method
  * @param  \PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode  $typeNode
+ * @param  int  $depth
  * @return string
  */
-function handleUnknownIdentifierType($method, $typeNode)
+function handleUnknownIdentifierType($method, $typeNode, $depth = 1)
 {
     $docblock = parseDocblock($method->getDocComment());
     $boundTemplateType = collect($docblock->getTemplateTagValues())->firstWhere('name', $typeNode->name)?->bound;
 
     if ($boundTemplateType !== null) {
-        $resolvedTemplateType = resolveDocblockTypes($method, $boundTemplateType);
+        // Forward depth so a union-typed bound (e.g. `TDefault of TEnum|null`) isn't
+        // re-wrapped in `(...)` at the outer depth==1 marker. The character-wise
+        // trim('()') in resolveReturnDocType / resolveDocParamType would otherwise
+        // strip both inner and outer parens unevenly, emitting an unbalanced tag
+        // like `\BackedEnum|(\BackedEnum|null`.
+        $resolvedTemplateType = resolveDocblockTypes($method, $boundTemplateType, $depth);
 
         if ($resolvedTemplateType !== null) {
             return $resolvedTemplateType;


### PR DESCRIPTION
The auto-generator emits a malformed `@method` tag when a method's `@return` references a template variable whose bound is a union (e.g. `TDefault of TEnum|null`). It currently breaks the `Illuminate\Support\Facades\Request` docblock and gets parsers like Psalm to drop every `@method` tag on the class. See psalm/psalm-plugin-laravel#886.

Repro on a tiny class:

```php
namespace MinimalRepro;

class TargetService
{
    /**
     * @template TEnum of \BackedEnum
     * @template TDefault of TEnum|null
     *
     * @param  string                 $key
     * @param  class-string<TEnum>    $enumClass
     * @param  TDefault               $default
     * @return TEnum|TDefault
     */
    public function pickEnum($key, $enumClass, $default = null)
    {
        return $default;
    }
}

/** @see \MinimalRepro\TargetService */
class TargetFacade extends \Illuminate\Support\Facades\Facade
{
    protected static function getFacadeAccessor() { return TargetService::class; }
}
```

```
$ php vendor/bin/facade.php --lint MinimalRepro\\TargetFacade
```

Before: `* @method static \BackedEnum|(\BackedEnum|null pickEnum(...)` (unbalanced)
After:  `* @method static \BackedEnum|\BackedEnum|null pickEnum(...)` (valid)

### What's going on

`resolveDocblockTypes()` wraps unions in `(...)` only at depth 1 so the trailing `trim($type, '()')` in `resolveReturnDocType()` knows what to strip. `handleUnknownIdentifierType()` recursed into a template bound without forwarding `$depth`, so the bound's union was treated as outermost and re-wrapped. Then `trim` (character-wise, not paren-balanced) stripped one `(` from the front and two `)`s from the back, breaking the balance.

The fix is to pass `$depth` through.

### Notes

- Output now has a duplicate (`\BackedEnum|\BackedEnum|null` vs the more compact `\BackedEnum|null`). `unique()` on `Collection<string>` can't collapse `\BackedEnum` and `\BackedEnum|null` (distinct strings). Properly deduping nested unions is a bigger rendering change and felt out of scope. The output is valid PHPDoc and parses cleanly everywhere I checked.
- I ran `--lint` against every facade in `laravel/framework`'s `facades.yml` workflow with both versions of the generator. Only the Request facade's `enum` line changes; everything else is byte-identical.
- `ConditionalTypeNode` handling at line 333 has the same shape (recurses without `$depth`). I couldn't construct a repro that breaks there, but worth a look in a follow-up.

Once this lands and a release is cut, the next push to `laravel/framework`'s `13.x` / `12.x` will run `facades.yml` and auto-commit the regenerated docblocks, so no separate framework PR is needed.